### PR TITLE
Explicitly add std feature for indexmap

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 serde = { version = "~1.0.147", optional = true, features = ["derive"] }
-indexmap = { version = "~1.9.1", optional = false }
+indexmap = { version = "~1.9.1", optional = false, features = ["std"] }
 
 [features]
 serde = ["dep:serde", "indexmap/serde"]


### PR DESCRIPTION
Add std feature to indexmap explicitly due to IntelliJ IDEs won't work with indexmap's hash_std which is custom cfg option in some specific environments could lead to fail builds

Recognized environments issuing build error:

Ubuntu 22.04 LTS with CLion 2022.2.4, stable-x86_64-unknown-linux-gnu of Rust toolchain and GCC 12.1

See also:

- https://github.com/bluss/indexmap/issues/184
- https://github.com/google/cargo-raze/issues/114
- https://github.com/intellij-rust/intellij-rust/issues/4631